### PR TITLE
CI build fix

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,13 +14,15 @@ workflows:
   # ----------------------------------------------------------------
   # --- workflow to Step Test
   ci:
-    before_run:
-    - go-tests
     after_run:
     - test_ios
     - test_android_custom_options
     - test_macos
     steps:
+    - go-list:
+    - golint:
+    - errcheck:
+    - go-test:
     - script:
         title: Cleanup _tmp dir
         inputs:
@@ -35,21 +37,11 @@ workflows:
         inputs:
         - path: ./_tmp
         - is_create_path: true
-    - git-clone:
-        title: Git clone Xamarin ios sample app
-        run_if: true
+    - script:
         inputs:
-        - repository_url: $SAMPLE_APP_URL
-        - clone_into_dir: ./
-        - commit: ""
-        - tag: ""
-        - branch: "master"
-        - pull_request_id: ""
-        - clone_depth: ""
+        - content: git clone $SAMPLE_APP_URL .
     - certificate-and-profile-installer:
         title: Install Code Sign files
-    - xamarin-user-management: 
-        title: Xamarin login
     - nuget-restore:
         title: Nuget restore
 
@@ -81,7 +73,6 @@ workflows:
     - path::./:
         title: Step test - android custom options
         inputs:
-        - build_tool: xbuild
         - project_type_whitelist: android
         - ios_build_command_custom_options: /nologo
     - script:
@@ -150,67 +141,6 @@ workflows:
             envman add --key BITRISE_MACOS_XCARCHIVE_PATH --value ""
             envman add --key BITRISE_MACOS_APP_PATH --value ""
             envman add --key BITRISE_MACOS_PKG_PATH --value ""
-
-  go-tests:
-    before_run:
-    - _install-test-tools
-    steps:
-    - script:
-        title: Export go files to test
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-
-            no_vendor_paths="$(go list ./... | grep -v vendor)"
-            envman add --key GOLIST_WITHOUT_VENDOR --value "$no_vendor_paths"
-    - script:
-        title: Err check
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-
-            errcheck -asserts=true -blank=true $GOLIST_WITHOUT_VENDOR
-    - script:
-        title: Go lint
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-
-            while read -r line; do
-              echo "-> Linting: $line"
-              golint_out="$(golint $line)"
-              if [[ "${golint_out}" != "" ]] ; then
-                echo "=> Golint issues found:"
-                echo "${golint_out}"
-                exit 1
-              fi
-            done <<< "$GOLIST_WITHOUT_VENDOR"
-    - script:
-        title: Go test
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-
-            go test ./...
-
-  _install-test-tools:
-    steps:
-    - script:
-        title: Install required testing tools
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-
-            # Check for unhandled errors
-            go get -u -v github.com/kisielk/errcheck
-
-            # Go lint
-            go get -u -v github.com/golang/lint/golint
 
   # ----------------------------------------------------------------
   # --- Utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,8 @@
-format_version: "2"
+format_version: "9"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - RELEASE_VERSION: 1.5.0
-
   - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-xamarin-cross-platform.git
   - BITRISE_PROJECT_PATH: Multiplatform.sln
   - BITRISE_XAMARIN_CONFIGURATION: Release
@@ -14,6 +12,8 @@ workflows:
   # ----------------------------------------------------------------
   # --- workflow to Step Test
   ci:
+    before_run:
+    - audit-this-step
     after_run:
     - test_ios
     - test_android_custom_options
@@ -162,21 +162,6 @@ workflows:
             godep save ./...
 
   # ----------------------------------------------------------------
-  # --- workflow to create Release version
-  create-release:
-    title: Create release with Releaseman
-    steps:
-    - script:
-        title:
-        inputs:
-        - content: |
-            #!/bin/bash
-            set -ex
-            go get -u github.com/bitrise-tools/releaseman
-            export CI=true
-            releaseman create --version "$RELEASE_VERSION"
-
-  # ----------------------------------------------------------------
   # --- workflow to Share this step into a Step Library
   audit-this-step:
     title: Audit the Step
@@ -187,39 +172,3 @@ workflows:
             #!/bin/bash
             set -ex
             stepman audit --step-yml ./step.yml
-
-  share-this-step:
-    envs:
-      # if you want to share this step into a StepLib
-      - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
-      - STEP_ID_IN_STEPLIB: xamarin-archive
-      - STEP_GIT_VERION_TAG_TO_SHARE: $RELEASE_VERSION
-      - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-xamarin-archive.git
-    title: Share the Step
-    description: |-
-      If this is the first time you try to share a Step you should
-      first call: $ bitrise share
-      This will print you a guide, and information about how Step sharing
-      works. Please read it at least once!
-      As noted in the Step sharing guide you'll have to fork the
-      StepLib you want to share this step into. Once you're done with forking
-      the repository you should set your own fork's git clone URL
-      in the `.bitrise.secrets.yml` file, or here in the `envs` section,
-      as the value of the `MY_STEPLIB_REPO_FORK_GIT_URL` environment.
-      You're now ready to share this Step, just make sure that
-      the `STEP_ID_IN_STEPLIB` and `STEP_GIT_VERION_TAG_TO_SHARE`
-      environments are set to the desired values!
-      To share this Step into a StepLib you can just run: $ bitrise run share-this-step
-      Once it finishes the only thing left is to actually create a Pull Request,
-      the way described in the guide printed at the end of the process.
-    before_run:
-    - audit-this-step
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            bitrise share start -c ${MY_STEPLIB_REPO_FORK_GIT_URL}
-            bitrise share create --stepid ${STEP_ID_IN_STEPLIB} --tag ${STEP_GIT_VERION_TAG_TO_SHARE} --git ${STEP_GIT_CLONE_URL}
-            bitrise share finish


### PR DESCRIPTION
- go test workflow updated
- removed `xbuild` test as it had issues, but it seems it is deprecated and will be removed soon, also there is no option to use `xbuild` from the IDE:  https://forums.xamarin.com/discussion/comment/346253/#Comment_346253