### PR TITLE
Support for Android bundle files

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -118,6 +118,7 @@ workflows:
         inputs:
         - content: |-
             echo "BITRISE_APK_PATH: $BITRISE_APK_PATH"
+            echo "BITRISE_AAB_PATH: $BITRISE_AAB_PATH"
             echo
             echo "BITRISE_XCARCHIVE_PATH: $BITRISE_XCARCHIVE_PATH"
             echo "BITRISE_IPA_PATH: $BITRISE_IPA_PATH"
@@ -134,6 +135,7 @@ workflows:
             echo "BITRISE_MACOS_PKG_PATH: $BITRISE_MACOS_PKG_PATH"
 
             envman add --key BITRISE_APK_PATH --value ""
+            envman add --key BITRISE_AAB_PATH --value ""
 
             envman add --key BITRISE_XCARCHIVE_PATH --value ""
             envman add --key BITRISE_IPA_PATH --value ""

--- a/main.go
+++ b/main.go
@@ -266,15 +266,29 @@ func main() {
 
 		for i, output := range projectOutput.Outputs {
 			log.Infof("%d/%d - %s - Type: %s", i+1, outputNumber, output.Pth, projectOutput.ProjectType)
+
 			// Android outputs
-			if projectOutput.ProjectType == constants.SDKAndroid && output.OutputType == constants.OutputTypeAPK {
-				envKey := "BITRISE_APK_PATH"
-				pth, err := exportArtifactFile(output.Pth, configs.DeployDir, envKey)
-				if err != nil {
-					failf("Failed to export apk, error: %s", err)
+			if projectOutput.ProjectType == constants.SDKAndroid {
+
+				if output.OutputType == constants.OutputTypeAPK {
+					envKey := "BITRISE_APK_PATH"
+					pth, err := exportArtifactFile(output.Pth, configs.DeployDir, envKey)
+					if err != nil {
+						failf("Failed to export apk, error: %s", err)
+					}
+					fmt.Println()
+					log.Printf("The apk path is now available in the Environment Variable: %s\nvalue: %s", envKey, pth)
 				}
-				fmt.Println()
-				log.Printf("The apk path is now available in the Environment Variable: %s\nvalue: %s", envKey, pth)
+
+				if output.OutputType == constants.OutputTypeAAB {
+					envKey := "BITRISE_AAB_PATH"
+					pth, err := exportArtifactFile(output.Pth, configs.DeployDir, envKey)
+					if err != nil {
+						failf("Failed to export aab, error: %s", err)
+					}
+					fmt.Println()
+					log.Printf("The aab path is now available in the Environment Variable: %s\nvalue: %s", envKey, pth)
+				}
 			}
 
 			// IOS outputs

--- a/step.yml
+++ b/step.yml
@@ -95,6 +95,9 @@ outputs:
   - BITRISE_APK_PATH: ""
     opts:
       title: The created android .apk file's path
+  - BITRISE_AAB_PATH: ""
+    opts:
+      title: The created android .aab file's path
   # iOS outputs
   - BITRISE_XCARCHIVE_PATH: ""
     opts:


### PR DESCRIPTION
## What's this?
This Pull Request makes the xamarin archive step not fail when archiving .aab files.
As mentioned in the issue this PR closes, everything else works (the Xamarin toolchain and the deploy to bitrise step) but we need this change so the archive steps passes (rather than failing with a false positive).

## Relationships
Depends on https://github.com/bitrise-io/go-xamarin/pull/49
Closes #35 

## How is it done?
This basically checks for the constant added in https://github.com/bitrise-io/go-xamarin/pull/49 and ensures that it can be uploaded. 

I'm really new to the whole bitrise steps thing, so bear with me if I forgot something important
